### PR TITLE
Update index.es. Support blog root other than '/'

### DIFF
--- a/index.es
+++ b/index.es
@@ -35,7 +35,7 @@ registers.forEach((register) => {
 
 hexo.extend.filter.register('after_post_render', (data) => {
 	data.content =
-		util.htmlTag('script', {src: '/' + scriptDir + aplayerScript}, ' ') +
+		util.htmlTag('script', {src: hexo.config.root + '/' + scriptDir + aplayerScript}, ' ') +
 		data.content;
 	return data;
 });


### PR DESCRIPTION
Allow hexo generate to run successfully when main _config.yml sets site root parameter to anything other than '/'.