### PR TITLE
fix: stop injecting into not-html files

### DIFF
--- a/index.es
+++ b/index.es
@@ -81,6 +81,11 @@ hexo.extend.filter.register('after_render:html', function(raw, info) {
 })
 
 hexo.extend.filter.register('after_post_render', (data) => {
+  // There is no need to inject scripts for some files like css or js which don't have layout.
+  if (data.layout === 'false') {
+    return;
+  }
+
   filterEmitted.after_post_render = true
   if (!config.get('asset_inject')) {
     return


### PR DESCRIPTION
Hi there!

With the same situation as this issue #44 .

It seems that the `layout` of files like `css` or `js` would be set as `false`.

Maybe check this before injecting would help.

Or using `PartialView.isFullPage` or `PartialView.hasHeadTag` maybe?
